### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+permissions:
+  contents: read
 on: [push]
 jobs:
   Explore-GitHub-Actions:


### PR DESCRIPTION
Potential fix for [https://github.com/jorgedelafuente/react-movies/security/code-scanning/1](https://github.com/jorgedelafuente/react-movies/security/code-scanning/1)

- In general, fix this by explicitly setting a `permissions` block either at the workflow root (applies to all jobs) or on the specific job, granting only the minimal scopes required (here, just read access to contents).
- For this specific workflow, the simplest, non‑breaking change is to add a root-level `permissions` section after the `run-name` (or after `name`) that restricts the `GITHUB_TOKEN` to `contents: read`. The existing steps (checkout, echoing variables, listing files) all work fine with read-only contents permission.
- Concretely, edit `.github/workflows/main.yml` to insert:
  ```yaml
  permissions:
    contents: read
  ```
  between line 2 and line 3 of the provided snippet. No other lines or behavior need to change, and no additional methods or imports are required because this is a YAML configuration-only adjustment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
